### PR TITLE
Update timeutils.inc

### DIFF
--- a/timeutils.inc
+++ b/timeutils.inc
@@ -7,7 +7,8 @@
     #define SERVER_TIME_ZONE (0)
 #endif
 
-static enum {
+static enum 
+{
 	SECONDS_PER_MINUTE = 60,
 	SECONDS_PER_HOUR = 3600,
 	SECONDS_PER_DAY = 86400,

--- a/timeutils.inc
+++ b/timeutils.inc
@@ -7,7 +7,7 @@
     #define SERVER_TIME_ZONE (0)
 #endif
 
-static const {
+static enum {
 	SECONDS_PER_MINUTE = 60,
 	SECONDS_PER_HOUR = 3600,
 	SECONDS_PER_DAY = 86400,

--- a/timeutils.inc
+++ b/timeutils.inc
@@ -7,15 +7,17 @@
     #define SERVER_TIME_ZONE (0)
 #endif
 
-#define SECONDS_PER_MINUTE (60)
-#define SECONDS_PER_HOUR (3600)
-#define SECONDS_PER_DAY (86400)
-#define SECONDS_PER_WEEK (604800)
-#define SECONDS_PER_MONTH (2592000)
-#define SECONDS_PER_YEAR (31536000)
+static const {
+	SECONDS_PER_MINUTE = 60,
+	SECONDS_PER_HOUR = 3600,
+	SECONDS_PER_DAY = 86400,
+	SECONDS_PER_WEEK = 604800,
+	SECONDS_PER_MONTH = 2592000,
+	SECONDS_PER_YEAR = 31536000,
 
-#define EPOCH_YEAR (1970)
-#define MAX_YEAR (2100)
+	EPOCH_YEAR = 1970,
+	MAX_YEAR = 2100
+};
 
 /**
  * Converts a time difference into human-readable format.


### PR DESCRIPTION
Removed definers and replaced them with const and static enumerators to avoid interactions outside the runtime file.
Depending on the compiler, the value declared in the definer significantly increases the size of the AMX file, so it's worth noting.